### PR TITLE
A diamond path leading to a loop did not cache what it should have.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ jobs:
             apt:
                 packages:
                 - g++-9
+                - libstdc++-8-dev
                 sources:
                 - ubuntu-toolchain-r-test
-        dist: xenial
+        dist: bionic
         env:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
         - TRACE_ENABLED=Yes
@@ -22,9 +23,10 @@ jobs:
             apt:
                 packages:
                 - g++-9
+                - libstdc++-8-dev
                 sources:
                 - ubuntu-toolchain-r-test
-        dist: xenial
+        dist: bionic
         env:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
         - CMAKE_BUILD_TYPE=Debug
@@ -33,9 +35,10 @@ jobs:
             apt:
                 packages:
                 - g++-9
+                - libstdc++-8-dev
                 sources:
                 - ubuntu-toolchain-r-test
-        dist: xenial
+        dist: bionic
         env:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
         - CMAKE_BUILD_TYPE=Release

--- a/src/lib/memhash.cpp
+++ b/src/lib/memhash.cpp
@@ -77,5 +77,7 @@ namespace {
 
 hash::digest vertex_hash (vertex const * const v, memoized_hashes * const table) {
     visited visited;
-    return std::get<digest_index> (vertex_hash_impl (v, table, &visited));
+    auto const result = std::get<digest_index> (vertex_hash_impl (v, table, &visited));
+    assert (visited.empty ());
+    return result;
 }

--- a/src/lib/memhash.cpp
+++ b/src/lib/memhash.cpp
@@ -16,29 +16,29 @@ namespace {
 
     auto vertex_hash_impl (vertex const * const v, memoized_hashes * const table,
                            visited * const visited) -> std::tuple<std::size_t, hash::digest> {
-        auto const num_visited = visited->size ();
-        trace ("Computing hash for ", *v, " (#", num_visited, ')');
+        auto const depth = visited->size ();
+        trace ("Computing hash for ", *v, " (#", depth, ')');
 
         // Have we computed the hash for this function already? If so, we can return the result
         // immediately.
         auto const table_pos = table->find (v);
         if (table_pos != table->end ()) {
             trace ("Returning pre-computed hash for ", *v);
-            return std::make_tuple (num_visited, table_pos->second);
+            return std::make_tuple (depth, table_pos->second);
         }
 
         hash h;
 
-        // Have we previously visited this vertex during this search? If so, add to the hash a
+        // Have we previously visited this vertex on this path? If so, add to the hash a
         // back-reference to that vertex and return its position to the caller. If not, record that
-        // we have visited this vertex and give it a numerical identifier. This will be used to form
-        // its back-reference if we loop back here in future.
-        auto const [visited_pos, inserted] = visited->try_emplace (v, num_visited);
+        // we have visited this vertex and its depth. This will be used to form a back-reference if
+        // we loop back here in future.
+        auto const [visited_pos, inserted] = visited->try_emplace (v, depth);
         if (!inserted) {
-            // Back-references are encoded as a number relative to the index of the current vertex.
+            // Back-references are encoded as a number relative to the depth of the current vertex.
             // Larger values are further back in the encoding.
-            assert (num_visited > visited_pos->second);
-            h.update_backref (num_visited - visited_pos->second - 1U);
+            assert (depth > visited_pos->second);
+            h.update_backref (depth - visited_pos->second - 1U);
             trace ("Returning back-ref to #", visited_pos->second);
             return std::make_tuple (visited_pos->second, h.finalize ());
         }
@@ -55,18 +55,19 @@ namespace {
             auto const adj_digest = vertex_hash_impl (out, table, visited);
             // A out-edge that points back to this same vertex doesn't count as a loop.
             if (out != v) {
-                loop_point = std::min (loop_point, std::get<0> (adj_digest));
+                loop_point = std::min (loop_point, std::get<std::size_t> (adj_digest));
             }
-            h.update_digest (std::get<1> (adj_digest));
+            h.update_digest (std::get<hash::digest> (adj_digest));
         }
         // We've encoded the final edge. Record that in the hash.
         h.update_end ();
 
         auto const result = std::make_tuple (loop_point, h.finalize ());
-        if (loop_point > num_visited) {
+        if (loop_point > depth) {
             trace ("Recording result for ", *v);
-            (*table)[v] = std::get<1> (result);
+            (*table)[v] = std::get<hash::digest> (result);
         }
+        visited->erase (v);
         return result;
     }
 
@@ -74,5 +75,5 @@ namespace {
 
 hash::digest vertex_hash (vertex const * const v, memoized_hashes * const table) {
     visited visited;
-    return std::get<1> (vertex_hash_impl (v, table, &visited));
+    return std::get<hash::digest> (vertex_hash_impl (v, table, &visited));
 }

--- a/src/unittests/test_memhash.cpp
+++ b/src/unittests/test_memhash.cpp
@@ -449,21 +449,21 @@ TEST (DigraphHash, DoubleLoop) {
     va.add_edge (&vc);
     vc.add_edge (&vb);
     {
+        memoized_hashes ma;
+        hash::digest const hva = vertex_hash (&va, &ma);
+        STRING_HASH_EXPECT_EQ (hva, "Va/Vb/R1E/Vc/Vb/R2EEE");
+        EXPECT_EQ (ma.size (), 0U);
+    }
+    {
         memoized_hashes mb;
-        hash::digest const hvb = vertex_hash (&va, &mb);
-        STRING_HASH_EXPECT_EQ (hvb, "Va/Vb/R1E/Vc/Vb/R2EEE");
+        hash::digest const hvb = vertex_hash (&vb, &mb);
+        STRING_HASH_EXPECT_EQ (hvb, "Vb/Va/R1/Vc/R2EEE");
         EXPECT_EQ (mb.size (), 0U);
     }
     {
         memoized_hashes mc;
-        hash::digest const hvc = vertex_hash (&vb, &mc);
-        STRING_HASH_EXPECT_EQ (hvc, "Vb/Va/R1/Vc/R2EEE");
+        hash::digest const hvc = vertex_hash (&vc, &mc);
+        STRING_HASH_EXPECT_EQ (hvc, "Vc/Vb/Va/R1/R2EEE");
         EXPECT_EQ (mc.size (), 0U);
-    }
-    {
-        memoized_hashes md;
-        hash::digest const hvd = vertex_hash (&vc, &md);
-        STRING_HASH_EXPECT_EQ (hvd, "Vc/Vb/Va/R1/R2EEE");
-        EXPECT_EQ (md.size (), 0U);
     }
 }


### PR DESCRIPTION
Start with a graph of the form “a → b → c → b; a → d → b;”. That is:

![graph](https://user-images.githubusercontent.com/2496470/82206222-c062bc00-98ff-11ea-8a90-0ad2d5620431.png)

Here we have a loop formed by “b → c → b” which leads directly from a ("a → b") and indirectly via d (“a → d → b”). Previously the algorithm would consider “d” to be later/deeper than “b” and thus consider it to lie inside the loop, which is clearly wrong.

The change corrects that by deleting entries in the collection of visited nodes as it back-tracks after having reached the end of each path. Now the number of entries in that container is always the depth of the traversal.

Add additional unit tests for this and a couple of other cases.